### PR TITLE
ci: auto-apply correctness label from PR template checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,8 @@ Thanks for sending a pull request!  Here are some tips for you:
 
 ### Does this PR resolve a correctness bug?
 
-<!-- Yes/No. (Note: If yes, committer will add `correctness` label to current pull request). -->
+<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
+- [ ] Yes
 
 ### Does this PR introduce _any_ user-facing change?
 

--- a/.github/workflows/correctness-label.yml
+++ b/.github/workflows/correctness-label.yml
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Correctness Label
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const LABEL = 'correctness';
+
+            // Extract only the "correctness bug" section (up to the next ### heading or end of body).
+            // Body is accessed via context.payload (JS), not via ${{ }} interpolation — no injection risk.
+            const sectionMatch = body.match(
+              /###\s*Does this PR resolve a correctness bug\?[\s\S]*?(?=\n###|$)/i
+            );
+            const isYes = sectionMatch != null &&
+              /- \[[xX]\] Yes/.test(sectionMatch[0]);
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo, issue_number: prNumber,
+            });
+            const hasLabel = currentLabels.some(l => l.name === LABEL);
+
+            if (isYes && !hasLabel) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber, labels: [LABEL],
+              });
+              core.info(`Added '${LABEL}' label`);
+            } else if (!isYes && hasLabel) {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: prNumber, name: LABEL,
+              });
+              core.info(`Removed '${LABEL}' label`);
+            } else {
+              core.info(`No label change needed (isYes=${isYes}, hasLabel=${hasLabel})`);
+            }


### PR DESCRIPTION
Replace the free-text Yes/No comment in PULL_REQUEST_TEMPLATE.md with a single checkbox. A new GitHub Actions workflow (correctness-label.yml) triggers on pull_request_target opened/edited/synchronize, parses the correctness section of the PR body, and adds or removes the `correctness` label automatically — no manual committer action needed.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?



### Why are the changes needed?



### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [x] Yes
### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

